### PR TITLE
Updated WSL check so it ignores case.

### DIFF
--- a/bin/setup-machine.sh
+++ b/bin/setup-machine.sh
@@ -89,7 +89,7 @@ win-reorder-previous-session='disabled'
 session-switch-to-terminal-left='disabled'"
 
 # '1' if running under Windows Subsystem for Linux, '0' otherwise.
-readonly WSL="$(grep -q Microsoft /proc/version && echo 1 || echo 0)"
+readonly WSL="$(grep -iq Microsoft /proc/version && echo 1 || echo 0)"
 
 # Install a bunch of debian packages.
 function install_packages() {


### PR DESCRIPTION
The WSL check fails on WSL2 installations running a customized kernel (which is reported to /proc/version with a capital "M") otherwise.