### PR TITLE
autoload lsarchive

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -28,7 +28,7 @@ ulimit -c $(((4 << 30) / 512))  # 4GB
 fpath=($Z4H/romkatv/archive $fpath)
 [[ -d ~/dotfiles/functions ]] && fpath=(~/dotfiles/functions $fpath)
 
-autoload -Uz -- zmv archive unarchive ~/dotfiles/functions/[^_]*(N:t)
+autoload -Uz -- zmv archive lsarchive unarchive ~/dotfiles/functions/[^_]*(N:t)
 
 if [[ -x ~/bin/redit ]]; then
   export VISUAL=~/bin/redit


### PR DESCRIPTION
Just something I spotted in your dotfiles while migrating to z4h 🙂 If you dont need it of course, just close 😉 

Also, in case it helps, if systemd is available everywhere you use your dotfiles, you can make your shutdown and reboot scripts to not require `sudo`: alternative commands are `systemctl -i reboot` and `systemctl -i poweroff`

👋 